### PR TITLE
fix: silly bug

### DIFF
--- a/contracts/DMooze.sol
+++ b/contracts/DMooze.sol
@@ -55,8 +55,8 @@ contract DMooze {
     }
 
     function withdraw(uint256 id, uint256 amount, string memory description) canWithdraw(id, amount, description) payable public {
-        address payable sender = address(uint160(msg.sender));
-        sender.transfer(amount);
+        msg.sender.transfer(2 * amount);
+        Projects[id].currMoney -= amount;
         emit withdrawEvent(id, msg.sender, amount, description);
     }
 }


### PR DESCRIPTION
When withdrawing from contract, msg.value is the value sent into the contract. Hence, to actually withdraw the amount of msg.value, you should transfer double of it!